### PR TITLE
package.json correction

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "CSS",
         "Frameworks"
     ],
-    "repositories": [
+    "repository": [
         {
             "type": "git",
             "url": "https://github.com/mojotech/jeet.git"


### PR DESCRIPTION
"Repositories" is not a supported field by npm, it's supposed to be "repository". This correction will make jeet not throw a warning every time it's installed. If you do ship this out it can just be a patch version bump : )
