### PR TITLE
[fix] uncycle in stylus

### DIFF
--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -26,7 +26,7 @@ column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
     &:nth-child({uncycle}n)
       margin-{opposite-position(side)}: (margin_r)%
       float: side
-    &:nth-child({cycle}n + 1)
+    &:nth-child({uncycle}n + 1)
       clear: none
   if cycle != 0
     &:nth-child({cycle}n)
@@ -64,7 +64,7 @@ span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
   if uncycle != 0
     &:nth-child({uncycle}n)
       float: side
-    &:nth-child({cycle}n + 1)
+    &:nth-child({uncycle}n + 1)
       clear: none
   if cycle != 0
     &:nth-child({cycle}n)


### PR DESCRIPTION
update the `uncycle` of stylus mixins as scss, of course make it works.

and the `span` mixin, in Stylus, seems different API from that in SCSS ? 
