### PR TITLE
Remove jeet-prefixer() mixin

### DIFF
--- a/scss/jeet/_grid.scss
+++ b/scss/jeet/_grid.scss
@@ -175,17 +175,17 @@
 // Horizontal/Vertical/Both Alignment - Parent container needs position relative. IE9+
 @mixin align($direction: both) {
   position: absolute;
-  @include jeet-prefixer(transform-style, preserve-3d);
+  transform-style: preserve-3d;
   @if ($direction == horizontal) or ($direction == h) {
     left: 50%;
-    @include jeet-prefixer(transform, translateX(-50%));
+    transform: translateX(-50%);
   } @else if ($direction == vertical) or ($direction == v) {
     top: 50%;
-    @include jeet-prefixer(transform, translateY(-50%));
+    transform: translateY(-50%);
   } @else {
     top: 50%;
     left: 50%;
-    @include jeet-prefixer(transform, translate(-50%, -50%));
+    transform: translate(-50%, -50%);
   }
 }
 
@@ -200,13 +200,3 @@
     clear: both;
   }
 }
-
-// Define a rule with all vendor-specific prefixes
-@mixin jeet-prefixer($name, $arguments) {
-  -webkit-#{$name}: #{$arguments};
-  -ms-#{$name}: #{$arguments};
-  -moz-#{$name}: #{$arguments};
-  -o-#{$name}: #{$arguments};
-  #{$name}: #{$arguments};
-}
-


### PR DESCRIPTION
Fixes #288.

Prefixing can be left to [autoprefixing software](https://github.com/postcss/autoprefixer), allowing only the required prefixes to be added, rather than all four of them being added in static manner, as is the current situation.
