### PR TITLE
Migrate INTEGRATIONS to Wiki

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -1,7 +1,0 @@
-# Jeet Integrations
-
-- [jeet-gulp](https://github.com/muraken720/jeet-gulp) - [Gulp](http://gulpjs.com) project with [LiveReload](http://livereload.com)
-- [generator-jeet](https://github.com/juliancwirko/generator-jeet) - [Yeoman](http://yeoman.io/) generator with [LiveReload](http://livereload.com)
-- [jeet-snippets](https://github.com/markalfred/jeet-snippets) - [Sublime Text](http://www.sublimetext.com) snippets
-- [Jeet in Meteor](http://atmospherejs.com/?q=jeet) - Meteor integrations via [Atmosphere](http://atmospherejs.com)
-- [scotty](https://github.com/juliancwirko/scotty) - [Meteor](http://meteor.com) boilerplate project

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Check out [this presentation](http://corysimmons.github.io/presentations/jeet-5)
 
 Want to sandbox it right this very second? Fork some examples on [CodePen](http://codepen.io/collection/eilAH/).
 
-Explore [Jeet Integrations](INTEGRATIONS.md) to see some community-backed plugins to your favorite frameworks and libraries.
+Explore [Jeet Integrations](https://github.com/mojotech/jeet/wiki/Jeet-Integrations) to see some community-backed plugins to your favorite frameworks and libraries.
 
 #### Browser Support
 - IE9+ and all major browsers without polyfills like Selectivizr


### PR DESCRIPTION
Too big for README. Too not-right for repo. These should go in Wiki.
