### PR TITLE
Remove the cycle and uncycle parameters from Stylus span mixin

### DIFF
--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -40,7 +40,7 @@ column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
 col = column
 
 // Columns without Gutters
-span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
+span(ratio = 1, offset = 0)
   side = -get_layout_direction()
   span_width = -get_span(ratio)
   margin_l = margin_r = 0
@@ -59,16 +59,6 @@ span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
   width: (span_width)%
   margin-{side}: (margin_l)%
   margin-{opposite-position(side)}: (margin_r)%
-  if uncycle != 0
-    &:nth-child({uncycle}n)
-      float: side
-    &:nth-child({uncycle}n + 1)
-      clear: none
-  if cycle != 0
-    &:nth-child({cycle}n)
-      float: opposite-position(side)
-    &:nth-child({cycle}n + 1)
-      clear: both
 
 // Source Ordering
 shift(ratios = 0, col_or_span = column, gutter = jeet.gutter)


### PR DESCRIPTION
Fixes #289.

There's no need for them as we are dealing with marginless columns.
