### PR TITLE
Fixed algorithm for reversing list in Sass 3.3

### DIFF
--- a/scss/jeet/_functions.scss
+++ b/scss/jeet/_functions.scss
@@ -85,7 +85,7 @@
   }
 
   // Sass 3.3
-  @for $i from 1 through floor(length($list) / 2) {
+  @for $i from 1 through floor(length($list) / 2) + 1 {
     $tmp: nth($list, $i);
     $list: set-nth($list, $i, nth($list, -$i));
     $list: set-nth($list, -$i, $tmp);


### PR DESCRIPTION
Loop starts from 1, should end at `1 + floor(length($list)/2)` instead of `floor(length($list)/2)`.

Fixed by adding +1 offset.
