### PR TITLE
Add offset mixin

### DIFF
--- a/scss/jeet/_grid.scss
+++ b/scss/jeet/_grid.scss
@@ -110,6 +110,44 @@
 }
 
 /**
+ * Add an offset to an element without outputting the column styles.
+ * @param {number} [$ratio=1] - The width of the offset, relative to its container.
+ * @param {string} [$col-or-span=column] - Whether you are offsetting a column or span.
+ * @param {number} [$gutter=$jeet-gutter] - Specifiy the gutter width as a percentage of the containers width.
+ * @warns if the default offset of 0 is left in place.
+ */
+@mixin offset($ratio: 0, $col-or-span: column, $gutter: $jeet-gutter) {
+  $side: jeet-get-layout-direction();
+  $opposite-side: jeet-opposite-direction($side);
+  $column-widths: jeet-get-column($ratio, $gutter);
+  $margin: 0;
+
+  @if $ratio != 0 {
+    @if $ratio < 0 {
+      $ratio: $ratio * -1;
+      @if index("column" "col" "c", $col-or-span) {
+        $ratio: nth(jeet-get-column($ratio, nth($column-widths, 2)), 1);
+        $margin: $ratio + nth($column-widths, 2) * 2;
+      } @else {
+        $margin: jeet-get-span($ratio);
+      }
+    } @else {
+      @if index("column" "col" "c", $col-or-span) {
+        $ratio: nth(jeet-get-column($ratio, nth($column-widths, 2)), 1);
+        $margin: $ratio + nth($column-widths, 2);
+      } @else {
+        $ratio: $ratio;
+        $margin: jeet-get-span($ratio);
+      }
+    }
+  } @else {
+    @warn "You need to specify an offset other than 0 to have any affect.";
+  }
+
+  margin-#{$side}: $margin * 1%;
+}
+
+/**
  * Reorder columns without altering the HTML.
  * @param {number} [$ratios=0] - Specify how far along you want the element to move.
  * @param {string} [$col-or-span=column] - Specify whether the element has a gutter or not.

--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -85,6 +85,37 @@ span(ratio = 1, offset = 0)
   margin-{opposite-side}: (margin-r)%
 
 /**
+ * Add an offset to an element without outputting the column styles.
+ * @param {number} [ratio=1] - The width of the offset, relative to its container.
+ * @param {string} [col-or-span=column] - Whether you are offsetting a column or span.
+ * @param {number} [gutter=jeet-gutter] - Specifiy the gutter width as a percentage of the containers width.
+ * @warns if the default offset of 0 is left in place.
+ */
+offset(ratio: 0, col-or-span: column, gutter: jeet-gutter)
+  side = jeet-get-layout-direction()
+  opposite-side = opposite-position(side)
+  column-widths = jeet-get-column(ratios, gutter)
+  margin = 0
+
+  if ratio != 0
+    if ratio < 0
+      ratio = ratio * -1
+      if col-or-span == column or col-or-span == col or col-or-span == c
+        ratio = jeet-get-column(ratio, column-widths[1])[0]
+        margin = ratio + column-widths[1] * 2
+      else
+        margin = jeet-get-span(ratio)
+    else
+      if col-or-span == column or col-or-span == col or col-or-span == c
+        ratio = jeet-get-column(ratio, column-widths[1])[0]
+        margin = ratio + column-widths[1]
+      else
+        ratio = ratio
+        margin = jeet-get-span(ratio)
+
+  margin-{side}: (margin)%
+
+/**
  * Reorder columns without altering the HTML.
  * @param {number} [ratios=0] - Specify how far along you want the element to move.
  * @param {string} [col-or-span=column] - Specify whether the element has a gutter or not.


### PR DESCRIPTION
An attempt to fix #191.

This PR adds the `offset()` mixin which can be accessed via:

``` scss
@include offset($ratio: 1/4, $col-or-span: column, $gutter: $jeet-gutter);
```

I've tested it on CodePen and it seems to work. **However** I'm worried that I've basically just duplicated a lot of code in order to make this happen. It seems to me that maybe Jeet could do with some refactoring.

Also, I'm pretty tired so it might be that my implementation is a bit inefficient. I'll probably wake up in the morning and see it more clearly :smile:
