### PR TITLE
Fix namespacing issue for jeet-replace-nth() call

### DIFF
--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -95,7 +95,7 @@ shift(ratios = 0, col_or_span = column, gutter = jeet.gutter)
   side = jeet-get-layout-direction()
 
   if side == right
-    ratios = -replace_nth(ratios, 0, ratios[0] * -1)
+    ratios = jeet-replace-nth(ratios, 0, ratios[0] * -1)
 
   if col_or_span == column or col_or_span == col or col_or_span == c
     column_widths = jeet-get-column(ratios, gutter)


### PR DESCRIPTION
Turns out I left a call to `jeet-replace-nth()` in the old form of `-replace_nth()` inside `_grid.styl`.

I've done a quick regex search for `" (-|_)[a-zA-Z]+"` to look for any strays and I'm 99.99% sure that's it :smile: 
