### PR TITLE
Add important parameter to the edit() mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+### 6.1.0
+- Enhancements
+ - Add `important` parameter to `edit()` mixin
+   - Defaults to `false`. When set to `true` it adds the `!important` flag to the CSS to force elements with backgrounds already set to show the debug grid. 
+
 ### 6.0.0
 - Enhancements
   - Scss and Stylus version now output identical CSS

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jeet",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "homepage": "http://jeet.gs",
   "authors": [
     "Cory Simmons <csimmonswork@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "main": "stylus/jeet.js",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "A grid system for humans.",
   "keywords": [
     "stylus",

--- a/scss/jeet/_grid.scss
+++ b/scss/jeet/_grid.scss
@@ -190,10 +190,17 @@
 /**
  * View the grid and its layers for easy debugging.
  * @param {string} [$color=black] - The background tint applied.
+ * @param {boolean} [$important=false] - Whether to apply the style as !important.
  */
-@mixin edit($color: black) {
-  * {
-    background: rgba($color, .05);
+@mixin edit($color: black, $important: false) {
+  @if $important {
+    * {
+      background: rgba($color, .05) !important;
+    }
+  } @else {
+    * {
+      background: rgba($color, .05);
+    }
   }
 }
 

--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -150,10 +150,15 @@ unshift()
 /**
  * View the grid and its layers for easy debugging.
  * @param {string} [color=black] - The background tint applied.
+ * @param {boolean} [important=false] - Whether to apply the style as !important.
  */
-edit(color = black)
-  *
-    background: rgba(color, 5%)
+edit(color = black, important = false)
+  if important
+    *
+      background: rgba(color, 5%) !important
+  else
+    *
+      background: rgba(color, 5%)
 
 /**
  *  Alias for edit().

--- a/tests/functions/edit/edit.scss
+++ b/tests/functions/edit/edit.scss
@@ -1,3 +1,5 @@
 @import 'scss/jeet/index';
 
 @include edit(blue);
+
+@include edit(blue, $important: true);

--- a/tests/functions/edit/edit.styl
+++ b/tests/functions/edit/edit.styl
@@ -1,3 +1,5 @@
 @import 'stylus/jeet/index'
 
 edit(blue)
+
+edit(blue, important: true)


### PR DESCRIPTION
Hey all,

This addresses #351.

With this you can pass an optional parameter through to `edit()` and it will output the usual code but with an `!important` flag. Useful for when your design has a lot of backgrounds set on elements that make the grid hard to see even with `edit()` active.

The tests pass, and I've checked both the Scss and Stylus versions on CodePen and they both work as intended.

Let me know what you think :smile: 
