### PR TITLE
Revert jeet-reverse() to it's old version to fix #354

### DIFF
--- a/scss/jeet/_functions.scss
+++ b/scss/jeet/_functions.scss
@@ -78,15 +78,24 @@
     $result: ();
 
     @for $i from length($list) * -1 through -1 {
-      $result: append($result, nth($list, abs($i)));
+      $item: nth($list, abs($i));
+
+      @if length($item) > 1 and $recursive {
+        $result: append($result, jeet-reverse($item, $recursive));
+      }
+      @else {
+        $result: append($result, $item);
+      }
     }
 
     @return $result;
   }
 
-  // Sass 3.3
-  @for $i from 1 through floor(length($list) / 2) + 1 {
+  // Sass 3.3+
+  @for $i from 1 through ceil(length($list)/2) {
     $tmp: nth($list, $i);
+    $tmp: if(length($tmp) > 1 and $recursive, reverse($tmp, $recursive), $tmp);
+
     $list: set-nth($list, $i, nth($list, -$i));
     $list: set-nth($list, -$i, $tmp);
   }

--- a/tests/functions/column/column.scss
+++ b/tests/functions/column/column.scss
@@ -1,5 +1,9 @@
 @import 'scss/jeet/index';
 
-.test {
+.test-1 {
   @include column($ratios: 1/5, $offset: 1/5, $cycle: 5, $uncycle: 5, $gutter: 5);
+}
+
+.test-2 {
+  @include column($ratios: 1/4 1/2, $offset: 1/4, $cycle: 4, $uncycle: 2, $gutter: 3);
 }

--- a/tests/functions/column/column.styl
+++ b/tests/functions/column/column.styl
@@ -1,4 +1,7 @@
 @import 'stylus/jeet/index'
 
-.test
+.test-1
   column(ratios: 1/5, offset: 1/5, cycle: 5, uncycle: 5, gutter: 5)
+
+.test-2
+  column(ratios: 1/4 1/2, offset: 1/4, cycle: 4, uncycle: 2, gutter: 3)


### PR DESCRIPTION
- Clean up old version a little
- Add extra tests to make sure context ratios output correct styles

If you experiment with [this Pen](http://codepen.io/clear-y/pen/xFkrv) you can see that commenting out the function breaks the layout.

As mentioned in #359 the tests fail seemingly due to number precision.

Is there any reason why this would cause issues with older/newer versions of Sass? Or was Hugo's optimisation just for our sake?
