### PR TITLE
Changing the syntax for overriding the default values in the stylus docs

### DIFF
--- a/stylus/README.md
+++ b/stylus/README.md
@@ -62,11 +62,11 @@ stylus -u nib -u axis-css -u autoprefixer-stylus -u rupture -u typographic -u je
 ```
 
 #### Global Settings
-- Create a `_settings.styl` file in your project directory somewhere. `@import '_settings'` at the top (right above `@import 'jeet'`) of whichever file Stylus is watching (e.g. `stylus -u jeet -w css/style.styl`)
+- Create a `_settings.styl` file in your project directory somewhere. `@import '_settings'` at the top (right after `@import 'jeet'`) of whichever file Stylus is watching (e.g. `stylus -u jeet -w css/style.styl`)
 - You can adjust the following variables:
-  - **`gutter = 3`** - The percentage of the page the root-level gutters take up.
-  - **`parent-first = false`** - When assigning multiple ratio contexts to a `col()`, do you want to reference the outer most container first? Example: Let's assume we have a column set to `col(1/4)` that is nested inside of another column that is `col(1/3)` which is nested inside of another column that is `col(1/2)`. By default, to maintain consistently sized gutters (even when nesting), our inner-most column would look like `col(1/4 1/3 1/2)`. If we adjust this global variable to be `true`, our inner-most column could be written from a top-down perspective like so: `col(1/2 1/3 1/4)`. This is entirely a preference thing. Do you like stepping up or down?
-  - **`layout-direction = LTR`** - Support for left-to-right, or right-to-left (`RTL`) text/layouts.
+  - **`jeet['gutter'] = 3`** - The percentage of the page the root-level gutters take up.
+  - **`jeet['parent-first'] = false`** - When assigning multiple ratio contexts to a `col()`, do you want to reference the outer most container first? Example: Let's assume we have a column set to `col(1/4)` that is nested inside of another column that is `col(1/3)` which is nested inside of another column that is `col(1/2)`. By default, to maintain consistently sized gutters (even when nesting), our inner-most column would look like `col(1/4 1/3 1/2)`. If we adjust this global variable to be `true`, our inner-most column could be written from a top-down perspective like so: `col(1/2 1/3 1/4)`. This is entirely a preference thing. Do you like stepping up or down?
+  - **`jeet['layout-direction'] = LTR`** - Support for left-to-right, or right-to-left (`RTL`) text/layouts.
 
 #### Gulp
 - `npm install gulp gulp-stylus jeet`


### PR DESCRIPTION
The docs around overriding the global settings were incorrect. Should close https://github.com/mojotech/jeet/issues/378
