### PR TITLE
[DON'T MERGE YET] Remove percentage sign when value is 0

### DIFF
--- a/scss/jeet/_functions.scss
+++ b/scss/jeet/_functions.scss
@@ -127,3 +127,16 @@
     @return false;
   }
 }
+
+/**
+ * Perform a value into a percentage value.
+ * @param {number} value - The value which should be converted.
+ * @returns {number} percentage
+ */
+@function jeet-get-percentage($value) {
+  @if $value == 0 {
+    @return 0;
+  } @else {
+    @return $value * 1%,;
+  }
+}

--- a/scss/jeet/_functions.scss
+++ b/scss/jeet/_functions.scss
@@ -130,8 +130,8 @@
 
 /**
  * Perform a value into a percentage value.
- * @param {number} value - The value which should be converted.
- * @returns {number} percentage
+ * @param {number} $value - The value which should be converted.
+ * @returns {number} $value - The percentage.
  */
 @function jeet-get-percentage($value) {
   @if $value == 0 {

--- a/scss/jeet/_grid.scss
+++ b/scss/jeet/_grid.scss
@@ -28,15 +28,15 @@
 
   float: $side;
   clear: none;
-  width: nth($column-widths, 1) * 1%;
+  width: jeet-get-percentage(nth($column-widths, 1));
   margin: {
-    #{$side}: $margin-l * 1%;
-    #{$opposite-side}: $margin-r * 1%;
+    #{$side}: jeet-get-percentage($margin-l);
+    #{$opposite-side}: jeet-get-percentage($margin-r);
   };
 
   @if $uncycle != 0 {
     &:nth-of-type(#{$uncycle}n) {
-      margin-#{jeet-opposite-direction($side)}: $margin-r * 1%;
+      margin-#{jeet-opposite-direction($side)}: jeet-get-percentage($margin-r);
       float: $side;
     }
     &:nth-of-type(#{$uncycle}n + 1) {
@@ -46,7 +46,7 @@
 
   @if $cycle != 0 {
     &:nth-of-type(#{$cycle}n) {
-      margin-#{jeet-opposite-direction($side)}: $margin-last * 1%;
+      margin-#{jeet-opposite-direction($side)}: jeet-get-percentage($margin-last);
       float: jeet-opposite-direction($side);
     }
     &:nth-of-type(#{$cycle}n + 1) {
@@ -54,7 +54,7 @@
     }
   } @else {
     &:last-child {
-      margin-#{jeet-opposite-direction($side)}: $margin-last * 1%;
+      margin-#{jeet-opposite-direction($side)}: jeet-get-percentage($margin-last);
     }
   }
 }
@@ -73,7 +73,7 @@
  * @param {number} [$gutter=$jeet-gutter] - Specify the gutter width as a percentage of the containers width.
  */
 @function column-width($ratios: 1, $gutter: $jeet-gutter) {
-  @return unquote(nth(jeet-get-column($ratios, $gutter), 1) + '%');
+  @return jeet-get-percentage(nth(jeet-get-column($ratios, $gutter), 1));
 }
 
 /**
@@ -82,7 +82,7 @@
  * @param {number} [gutter=jeet.gutter] - Specify the gutter width as a percentage of the containers width.
  */
 @function column-gutter($ratios: 1, $gutter: $jeet-gutter) {
-  @return unquote(nth(jeet-get-column($ratios, $gutter), 2) + '%');
+  @return jeet-get-percentage(nth(jeet-get-column($ratios, $gutter), 2));
 }
 
 /**
@@ -125,10 +125,10 @@
 
   float: $side;
   clear: none;
-  width: $span-width * 1%;
+  width: jeet-get-percentage($span-width);
   margin: {
-    #{$side}: $margin-l * 1%;
-    #{$opposite-side}: $margin-r * 1%;
+    #{$side}: jeet-get-percentage($margin-l);
+    #{$opposite-side}: jeet-get-percentage($margin-r);
   };
 
   @if $cycle != 0 {
@@ -173,7 +173,7 @@
   }
 
   position: relative;
-  left: $translate * 1%;
+  left: jeet-get-percentage($translate);
 }
 
 /**

--- a/stylus/jeet/_functions.styl
+++ b/stylus/jeet/_functions.styl
@@ -62,3 +62,14 @@ jeet-reverse(list)
     prepend(result, item)
 
   return result
+
+/**
+ * Perform a value into a percentage value.
+ * @param {number} value - The value which should be converted.
+ * @returns {number} percentage
+ */
+jeet-get-percentage(value)
+  if value == 0
+    return 0
+  else
+    return (value)%

--- a/stylus/jeet/_functions.styl
+++ b/stylus/jeet/_functions.styl
@@ -66,7 +66,7 @@ jeet-reverse(list)
 /**
  * Perform a value into a percentage value.
  * @param {number} value - The value which should be converted.
- * @returns {number} percentage
+ * @returns {number} value - The percentage.
  */
 jeet-get-percentage(value)
   if value == 0

--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -25,26 +25,26 @@ column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
 
   float: side
   clear: none
-  width: (column-widths[0])%
-  margin-{side}: (margin-l)%
-  margin-{opposite-side}: (margin-r)%
+  width: jeet-get-percentage(column-widths[0])
+  margin-{side}: jeet-get-percentage(margin-l)
+  margin-{opposite-side}: jeet-get-percentage(margin-r)
 
   if uncycle != 0
     &:nth-of-type({uncycle}n)
-      margin-{opposite-side}: (margin-r)%
+      margin-{opposite-side}: jeet-get-percentage(margin-r)
       float: side
     &:nth-of-type({uncycle}n+1)
       clear: none
 
   if cycle != 0
     &:nth-of-type({cycle}n)
-      margin-{opposite-side}: (margin-last)%
+      margin-{opposite-side}: jeet-get-percentage(margin-last)
       float: opposite-side
     &:nth-of-type({cycle}n+1)
       clear: both
    else
     &:last-child
-      margin-{opposite-side}: (margin-last)%
+      margin-{opposite-side}: jeet-get-percentage(margin-last)
 
 /**
  * An alias for the column mixin.
@@ -57,7 +57,7 @@ col = column
  * @param {number} [gutter=jeet.gutter] - Specify the gutter width as a percentage of the containers width.
  */
 column-width(ratios = 1, gutter = jeet.gutter)
-  return jeet-get-column(ratios, gutter)[0] + '%'
+  return jeet-get-percentage(jeet-get-column(ratios, gutter)[0])
 
 /**
  * An alias for the column-width function.
@@ -70,7 +70,7 @@ cw = column-width
  * @param {number} [gutter=jeet.gutter] - Specify the gutter width as a percentage of the containers width.
  */
 column-gutter(ratios = 1, gutter = jeet.gutter)
-  return jeet-get-column(ratios, gutter)[1] + '%'
+  return jeet-get-percentage(jeet-get-column(ratios, gutter)[1])
 
 /**
  * An alias for the column-gutter function.
@@ -100,9 +100,9 @@ span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
 
   float: side
   clear: none
-  width: (span-width)%
-  margin-{side}: (margin-l)%
-  margin-{opposite-side}: (margin-r)%
+  width: jeet-get-percentage(span-width)
+  margin-{side}: jeet-get-percentage(margin-l)
+  margin-{opposite-side}: jeet-get-percentage(margin-r)
 
   if cycle != 0
     &:nth-of-type({cycle}n)
@@ -136,7 +136,7 @@ shift(ratios = 0, col-or-span = column, gutter = jeet.gutter)
     translate = jeet-get-span(ratios)
 
   position: relative
-  left: (translate)%
+  left: jeet-get-percentage(translate)
 
 /**
  * Reset an element that has had shift() applied to it.


### PR DESCRIPTION
I added a jeet-get-percentage function which checks if the value is 0, when it is 0 it just returns 0, otherwise it returns the value as a percentage value. this function is now used on all relevant values in the grid.

all changes happend in sass and stylus

Codepens:
 * sass: http://codepen.io/di5abled/pen/ZYpqbP 
 * stylus: http://codepen.io/di5abled/pen/MYjPaL 