### PR TITLE
[DON'T MERGE] Remove text-align: inherit

### DIFF
--- a/scss/jeet/_grid.scss
+++ b/scss/jeet/_grid.scss
@@ -29,7 +29,6 @@
   @include cf;
   float: $side;
   clear: none;
-  text-align: inherit;
   width: nth($column-widths, 1) * 1%;
   margin: {
     #{$side}: $margin-l * 1%;
@@ -128,7 +127,6 @@
   @include cf;
   float: $side;
   clear: none;
-  text-align: inherit;
   width: $span-width * 1%;
   margin: {
     #{$side}: $margin-l * 1%;

--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -26,7 +26,6 @@ column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
   cf()
   float: side
   clear: none
-  text-align: inherit
   width: (column-widths[0])%
   margin-{side}: (margin-l)%
   margin-{opposite-side}: (margin-r)%
@@ -103,7 +102,6 @@ span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
   cf()
   float: side
   clear: none
-  text-align: inherit
   width: (span-width)%
   margin-{side}: (margin-l)%
   margin-{opposite-side}: (margin-r)%


### PR DESCRIPTION
Just removes the `text-align: inherit;` declarations. Fixes #393.