### PR TITLE
[DON'T MERGE] Remove cf() from column/span/center declarations

### DIFF
--- a/scss/jeet/_grid.scss
+++ b/scss/jeet/_grid.scss
@@ -26,7 +26,6 @@
     }
   }
 
-  @include cf;
   float: $side;
   clear: none;
   width: nth($column-widths, 1) * 1%;
@@ -124,7 +123,6 @@
     }
   }
 
-  @include cf;
   float: $side;
   clear: none;
   width: $span-width * 1%;
@@ -216,7 +214,6 @@
  * @param {number} [$pad=0] - Specify the element's left and right padding.
  */
 @mixin center($max-width: $jeet-max-width, $pad: 0) {
-  @include cf;
   width: auto;
   max-width: $max-width;
   float: none;

--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -23,7 +23,6 @@ column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
       offset = jeet-get-column(offset, column-widths[1])[0]
       margin-l = offset + column-widths[1]
 
-  cf()
   float: side
   clear: none
   width: (column-widths[0])%
@@ -99,7 +98,6 @@ span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
     else
       margin-l = jeet-get-span(offset)
 
-  cf()
   float: side
   clear: none
   width: (span-width)%
@@ -171,7 +169,6 @@ debug = edit
  * @param {number} [pad=0] - Specify the element's left and right padding.
  */
 center(max-width = jeet.max-width, pad = 0)
-  cf()
   width: auto
   max-width: max-width
   float: none


### PR DESCRIPTION
Fixes #372.

This just removes `cf()` from inside mixins. People should manually specify clearfixes, and more ideally, use a placeholder to more greatly reduce outputted CSS.