### PR TITLE
Get rid of superfluous uncycle param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 7.0.0
+- Enhancements
+  - Remove superfluous uncycle parameter
+
 ### 6.1.2
 - Fixes
   - Critical bug in Scss port that caused nested columns to have incorrect gutters.
@@ -9,8 +13,8 @@
 
 ### 6.1.0
 - Enhancements
- - Add `important` parameter to `edit()` mixin
-   - Defaults to `false`. When set to `true` it adds the `!important` flag to the CSS to force elements with backgrounds already set to show the debug grid.
+  - Add `important` parameter to `edit()` mixin
+    - Defaults to `false`. When set to `true` it adds the `!important` flag to the CSS to force elements with backgrounds already set to show the debug grid.
 
 ### 6.0.0
 - Enhancements

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 <img width="190px" src="https://mojotech.github.io/jeet/img/jeet-logo-color.svg" title="Jeet Grid System">
 </p>
 
-[![Build Status](https://travis-ci.org/mojotech/jeet.svg?branch=master)](https://travis-ci.org/mojotech/jeet)
-
 [Jeet](http://jeet.gs) is the most advanced, yet intuitive, grid system on the market today. You can think of it like the spiritual successor to [Semantic.gs](http://semantic.gs/).
 
 By making use of the power of pre-processors, we can now pass real fractions (or float numbers) as context that generates a percentage based width and gutter for grids. We're able to do this while maintaining a consistently sized infinitely nestable gutter.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 <p align="center">
-<img width="190px" src="https://mojotech.github.io/jeet/img/jeet-logo-color.svg" title="Jeet Grid System">
+  <img width="190px" src="https://mojotech.github.io/jeet/img/jeet-logo-color.svg" title="Jeet Grid System">
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/npm/v/jeet.svg">
+  <img src="https://img.shields.io/bower/v/jeet.svg">
+  <img src="http://img.shields.io/npm/dm/jeet.svg">
 </p>
 
 [Jeet](http://jeet.gs) is the most advanced, yet intuitive, grid system on the market today. You can think of it like the spiritual successor to [Semantic.gs](http://semantic.gs/).

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jeet",
-  "version": "6.1.2",
+  "version": "7.0.0",
   "homepage": "http://jeet.gs",
   "authors": [
     "Cory Simmons <csimmonswork@gmail.com>",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "7.0.0",
   "homepage": "http://jeet.gs",
   "authors": [
-    "Cory Simmons <csimmonswork@gmail.com>",
+    "Cory Simmons <cory@launchboxhq.com>",
     "Sam Saccone <sam@mojotech.com>",
     "Jake Cleary <shout@jakecleary.net>"
   ],

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "maintainers": [
     {
       "name": "Cory Simmons",
-      "email": "csimmonswork@gmail.com",
-      "web": "http://jeet.gs"
+      "email": "cory@launchboxhq.com",
+      "web": "http://launchboxhq.com"
     },
     {
       "name": "Sam Saccone",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "main": "stylus/jeet.js",
-  "version": "6.1.2",
+  "version": "7.0.0",
   "description": "A grid system for humans.",
   "keywords": [
     "stylus",

--- a/scss/jeet/_grid.scss
+++ b/scss/jeet/_grid.scss
@@ -3,10 +3,9 @@
  * @param {number} [$ratios=1] - A width relative to its container as a fraction.
  * @param {number} [$offset=0] - A offset specified as a fraction (see $ratios).
  * @param {number} [$cycle=0] - Easily create an nth column grid where $cycle equals the number of columns.
- * @param {number} [$uncycle=0] - Undo a previous cycle value to allow for a new one.
  * @param {number} [$gutter=$jeet-gutter] - Specify the gutter width as a percentage of the containers width.
  */
-@mixin column($ratios: 1, $offset: 0, $cycle: 0, $uncycle: 0, $gutter: $jeet-gutter) {
+@mixin column($ratios: 1, $offset: 0, $cycle: 0, $gutter: $jeet-gutter) {
   $side: jeet-get-layout-direction();
   $opposite-side: jeet-opposite-direction($side);
   $column-widths: jeet-get-column($ratios, $gutter);
@@ -34,17 +33,12 @@
     #{$opposite-side}: jeet-get-percentage($margin-r);
   };
 
-  @if $uncycle != 0 {
-    &:nth-of-type(#{$uncycle}n) {
+  @if $cycle != 0 {
+    &:nth-of-type(n) {
       margin-#{jeet-opposite-direction($side)}: jeet-get-percentage($margin-r);
       float: $side;
-    }
-    &:nth-of-type(#{$uncycle}n + 1) {
       clear: none;
     }
-  }
-
-  @if $cycle != 0 {
     &:nth-of-type(#{$cycle}n) {
       margin-#{jeet-opposite-direction($side)}: jeet-get-percentage($margin-last);
       float: jeet-opposite-direction($side);
@@ -105,10 +99,9 @@
  * Style an element as a column without any gutters for a seamless row.
  * @param {number} [$ratios=1] - A width relative to its container as a fraction.
  * @param {number} [$offset=0] - A offset specified as a fraction (see $ratios).
- * @param {number} [cycle=0] - Easily create an nth column grid where cycle equals the number of columns.
- * @param {number} [uncycle=0] - Undo a previous cycle value to allow for a new one.
+ * @param {number} [$cycle=0] - Easily create an nth column grid where cycle equals the number of columns.
  */
-@mixin span($ratio: 1, $offset: 0, $cycle: 0, $uncycle: 0) {
+@mixin span($ratio: 1, $offset: 0, $cycle: 0) {
   $side: jeet-get-layout-direction();
   $opposite-side: jeet-opposite-direction($side);
   $span-width: jeet-get-span($ratio);
@@ -132,20 +125,15 @@
   };
 
   @if $cycle != 0 {
+    &:nth-of-type(n) {
+      float: $side;
+      clear: none;
+    }
     &:nth-of-type(#{$cycle}n) {
       float: $opposite-side;
     }
     &:nth-of-type(#{$cycle}n + 1) {
       clear: both;
-    }
-  }
-
-  @if $uncycle != 0 {
-    &:nth-of-type(#{$uncycle}n) {
-      float: $side;
-    }
-    &:nth-of-type(#{$uncycle}n + 1) {
-      clear: none;
     }
   }
 

--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -3,10 +3,9 @@
  * @param {number} [ratios=1] - A width relative to its container as a fraction.
  * @param {number} [offset=0] - A offset specified as a fraction (see ratios).
  * @param {number} [cycle=0] - Easily create an nth column grid where cycle equals the number of columns.
- * @param {number} [uncycle=0] - Undo a previous cycle value to allow for a new one.
  * @param {number} [gutter=jeet.gutter] - Specify the gutter width as a percentage of the containers width.
  */
-column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
+column(ratios = 1, offset = 0, cycle = 0, gutter = jeet.gutter)
   side = jeet-get-layout-direction()
   opposite-side = opposite-position(side)
   column-widths = jeet-get-column(ratios, gutter)
@@ -29,14 +28,11 @@ column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
   margin-{side}: jeet-get-percentage(margin-l)
   margin-{opposite-side}: jeet-get-percentage(margin-r)
 
-  if uncycle != 0
-    &:nth-of-type({uncycle}n)
+  if cycle != 0
+    &:nth-of-type(n)
       margin-{opposite-side}: jeet-get-percentage(margin-r)
       float: side
-    &:nth-of-type({uncycle}n+1)
       clear: none
-
-  if cycle != 0
     &:nth-of-type({cycle}n)
       margin-{opposite-side}: jeet-get-percentage(margin-last)
       float: opposite-side
@@ -82,9 +78,8 @@ cg = column-gutter
  * @param {number} [ratios=1] - A width relative to its container as a fraction.
  * @param {number} [offset=0] - A offset specified as a fraction (see ratios).
  * @param {number} [cycle=0] - Easily create an nth column grid where cycle equals the number of columns.
- * @param {number} [uncycle=0] - Undo a previous cycle value to allow for a new one.
  */
-span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
+span(ratio = 1, offset = 0, cycle = 0)
   side = jeet-get-layout-direction()
   opposite-side = opposite-position(side)
   span-width = jeet-get-span(ratio)
@@ -105,16 +100,13 @@ span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
   margin-{opposite-side}: jeet-get-percentage(margin-r)
 
   if cycle != 0
+    &:nth-of-type(n)
+      float: side
+      clear: none
     &:nth-of-type({cycle}n)
       float: opposite-side
     &:nth-of-type({cycle}n + 1)
       clear: both
-
-  if uncycle != 0
-    &:nth-of-type({uncycle}n)
-      float: side
-    &:nth-of-type({uncycle}n + 1)
-      clear: none
 
 /**
  * Reorder columns without altering the HTML.

--- a/tests/functions/column/column.scss
+++ b/tests/functions/column/column.scss
@@ -1,9 +1,9 @@
 @import 'scss/jeet/index';
 
 .test-1 {
-  @include column($ratios: 1/5, $offset: 1/5, $cycle: 5, $uncycle: 5, $gutter: 5);
+  @include column($ratios: 1/5, $offset: 1/5, $cycle: 5, $gutter: 5);
 }
 
 .test-2 {
-  @include column($ratios: 1/4 1/2, $offset: 1/4, $cycle: 4, $uncycle: 2, $gutter: 3);
+  @include column($ratios: 1/4 1/2, $offset: 1/4, $cycle: 4, $gutter: 3);
 }

--- a/tests/functions/column/column.styl
+++ b/tests/functions/column/column.styl
@@ -1,7 +1,7 @@
 @import 'stylus/jeet/index'
 
 .test-1
-  column(ratios: 1/5, offset: 1/5, cycle: 5, uncycle: 5, gutter: 5)
+  column(ratios: 1/5, offset: 1/5, cycle: 5, gutter: 5)
 
 .test-2
-  column(ratios: 1/4 1/2, offset: 1/4, cycle: 4, uncycle: 2, gutter: 3)
+  column(ratios: 1/4 1/2, offset: 1/4, cycle: 4, gutter: 3)

--- a/tests/functions/span/span.scss
+++ b/tests/functions/span/span.scss
@@ -1,5 +1,5 @@
 @import 'scss/jeet/index';
 
 .test {
-  @include span($ratio: 1/5, $offset: 1/5, $cycle: 5, $uncycle: 5);
+  @include span($ratio: 1/5, $offset: 1/5, $cycle: 5);
 }

--- a/tests/functions/span/span.styl
+++ b/tests/functions/span/span.styl
@@ -1,4 +1,4 @@
 @import 'stylus/jeet/index'
 
 .test
-  span(ratio: 1/5, offset: 1/5, cycle: 5, uncycle: 5)
+  span(ratio: 1/5, offset: 1/5, cycle: 5)


### PR DESCRIPTION
Figured this out over at https://github.com/corysimmons/lost and felt like Jeet could benefit from it.

This effectively gets rid of the `uncycle` param from `cycle()` and `span()`. It's pretty handy since `uncycle` was always kind of a pain to keep up with throughout media queries.

It's an API breaking change since `column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)` will now be missing a param, so `gutter` would become the 4th param instead of `uncycle`.

`column(1/2, 1/2, 2, **3**, 30px)` becomes `column(1/2, 1/2, 2, 30px)`.

I'm pretty sure this will need bumped to 7.0.0 to adhere to semver, but I think @jakecleary is already working on a ton of stuff for 7.0.0.

Feel free to let this lay dormant.

Also feel free to remove me from maintainers if you want.