### PR TITLE
Prefix the API methods with `j-`

### DIFF
--- a/scss/jeet/_grid.scss
+++ b/scss/jeet/_grid.scss
@@ -6,7 +6,7 @@
  * @param {number} [$uncycle=0] - Undo a previous cycle value to allow for a new one.
  * @param {number} [$gutter=$jeet-gutter] - Specify the gutter width as a percentage of the containers width.
  */
-@mixin column($ratios: 1, $offset: 0, $cycle: 0, $uncycle: 0, $gutter: $jeet-gutter) {
+@mixin j-column($ratios: 1, $offset: 0, $cycle: 0, $uncycle: 0, $gutter: $jeet-gutter) {
   $side: jeet-get-layout-direction();
   $opposite-side: jeet-opposite-direction($side);
   $column-widths: jeet-get-column($ratios, $gutter);
@@ -60,11 +60,15 @@
 }
 
 /**
- * An alias for the column mixin.
- * @param [$args...] - All arguments get passed through to column().
+ * Aliases for j-column().
  */
+
+@mixin column($args...) {
+  @include j-column($args...);
+}
+
 @mixin col($args...) {
-  @include column($args...);
+  @include j-column($args...);
 }
 
 /**
@@ -72,8 +76,20 @@
  * @param {number} [$ratios=1] - A width relative to its container as a fraction.
  * @param {number} [$gutter=$jeet-gutter] - Specify the gutter width as a percentage of the containers width.
  */
-@function column-width($ratios: 1, $gutter: $jeet-gutter) {
+@function j-column-width($ratios: 1, $gutter: $jeet-gutter) {
   @return jeet-get-percentage(nth(jeet-get-column($ratios, $gutter), 1));
+}
+
+/**
+ * Aliases for j-column-width().
+ */
+
+@function column-width($args...) {
+  @return j-column-width($args...);
+}
+
+@function cw($args...) {
+  @return j-column-width($args...);
 }
 
 /**
@@ -81,24 +97,20 @@
  * @param {number} [ratios=1] - A width relative to its container as a fraction.
  * @param {number} [gutter=jeet.gutter] - Specify the gutter width as a percentage of the containers width.
  */
-@function column-gutter($ratios: 1, $gutter: $jeet-gutter) {
+@function j-column-gutter($ratios: 1, $gutter: $jeet-gutter) {
   @return jeet-get-percentage(nth(jeet-get-column($ratios, $gutter), 2));
 }
 
 /**
- * An alias for the column-width function.
- * @param [$args...] - All arguments get passed through to column().
+ * Alias for j-column-gutter().
  */
-@function cw($args...) {
-  @return column-width($args...);
+
+@function column-gutter($args...) {
+  @return j-column-gutter($args...);
 }
 
-/**
- * An alias for the column-gutter function.
- * @param [$args...] - All arguments get passed through to column().
- */
 @function cg($args...) {
-  @return column-gutter($args...);
+  @return j-column-gutter($args...);
 }
 
 /**
@@ -108,7 +120,7 @@
  * @param {number} [cycle=0] - Easily create an nth column grid where cycle equals the number of columns.
  * @param {number} [uncycle=0] - Undo a previous cycle value to allow for a new one.
  */
-@mixin span($ratio: 1, $offset: 0, $cycle: 0, $uncycle: 0) {
+@mixin j-span($ratio: 1, $offset: 0, $cycle: 0, $uncycle: 0) {
   $side: jeet-get-layout-direction();
   $opposite-side: jeet-opposite-direction($side);
   $span-width: jeet-get-span($ratio);
@@ -152,12 +164,19 @@
 }
 
 /**
+ * Alias for j-span().
+ */
+@mixin span($args...) {
+  @include j-span($args...);
+}
+
+/**
  * Reorder columns without altering the HTML.
  * @param {number} [$ratios=0] - Specify how far along you want the element to move.
  * @param {string} [$col-or-span=column] - Specify whether the element has a gutter or not.
  * @param {number} [$gutter=$jeet-gutter] - Specify the gutter width as a percentage of the containers width.
  */
-@mixin shift($ratios: 0, $col-or-span: column, $gutter: $jeet-gutter) {
+@mixin j-shift($ratios: 0, $col-or-span: column, $gutter: $jeet-gutter) {
   $translate: '';
   $side: jeet-get-layout-direction();
 
@@ -177,11 +196,25 @@
 }
 
 /**
+ * Alias for j-shift().
+ */
+@mixin shift($args...) {
+  @include j-shit($args...);
+}
+
+/**
  * Reset an element that has had shift() applied to it.
  */
-@mixin unshift() {
+@mixin j-unshift() {
   position: static;
   left: 0;
+}
+
+/**
+ * Alias for j-unshift().
+ */
+@mixin unshift() {
+  @include j-unshit();
 }
 
 /**
@@ -189,7 +222,7 @@
  * @param {string} [$color=black] - The background tint applied.
  * @param {boolean} [$important=false] - Whether to apply the style as !important.
  */
-@mixin edit($color: black, $important: false) {
+@mixin j-edit($color: black, $important: false) {
   @if $important {
     * {
       background: rgba($color, .05) !important;
@@ -202,10 +235,15 @@
 }
 
 /**
- *  Alias for edit().
+ * Aliases for j-edit().
  */
-@mixin debug() {
-  @include edit;
+
+@mixin edit($args...) {
+  @include j-edit($args...);
+}
+
+@mixin debug($args...) {
+  @include j-edit($args...);
 }
 
 /**
@@ -213,7 +251,7 @@
  * @param {number} [$max-width=1410px] - The max width the element can be.
  * @param {number} [$pad=0] - Specify the element's left and right padding.
  */
-@mixin center($max-width: $jeet-max-width, $pad: 0) {
+@mixin j-center($max-width: $jeet-max-width, $pad: 0) {
   width: auto;
   max-width: $max-width;
   float: none;
@@ -229,9 +267,16 @@
 }
 
 /**
+ * Alias for j-center().
+ */
+@mixin center($args...) {
+  @include j-center($args...);
+}
+
+/**
  * Uncenter an element.
  */
-@mixin uncenter() {
+@mixin j-uncenter() {
   max-width: none;
   margin-right: 0;
   margin-left: 0;
@@ -240,11 +285,18 @@
 }
 
 /**
+ * Alias for j-uncenter().
+ */
+@mixin uncenter() {
+  @include j-uncenter;
+}
+
+/**
  * Stack an element so that nothing is either side of it.
  * @param {number} [$pad=0] - Specify the element's left and right padding.
  * @param {boolean/string} [$align=false] - Specify the text align for the element.
  */
-@mixin stack($pad: 0, $align: false) {
+@mixin j-stack($pad: 0, $align: false) {
   $side: jeet-get-layout-direction();
   $opposite-side: jeet-opposite-direction($side);
 
@@ -284,9 +336,16 @@
 }
 
 /**
+ * Alias for j-stack().
+ */
+@mixin stack($args...) {
+  @include j-stack($args...);
+}
+
+/**
  * Unstack an element.
  */
-@mixin unstack() {
+@mixin j-unstack() {
   $side: jeet-get-layout-direction();
   $opposite-side: jeet-opposite-direction($side);
 
@@ -309,11 +368,18 @@
 }
 
 /**
+ * Alias for j-unstack().
+ */
+@mixin unstack() {
+  @include j-unstack();
+}
+
+/**
  * Center an element on either or both axes.
  * @requires A parent container with relative positioning.
  * @param {string} [$direction=both] - Specify which axes to center the element on.
  */
-@mixin align($direction: both) {
+@mixin j-align($direction: both) {
   position: absolute;
   transform-style: preserve-3d;
 
@@ -335,9 +401,16 @@
 }
 
 /**
+ * Alias for j-align().
+ */
+@mixin align($args...) {
+  @include j-align($args...);
+}
+
+/**
  * Apply a clearfix to an element.
  */
-@mixin cf() {
+@mixin j-cf() {
   *zoom: 1;
 
   &:before, &:after {
@@ -348,4 +421,11 @@
   &:after {
     clear: both;
   }
+}
+
+/**
+ * Alias for j-cf().
+ */
+@mixin cf() {
+  @include j-cf();
 }

--- a/scss/jeet/_grid.scss
+++ b/scss/jeet/_grid.scss
@@ -199,7 +199,7 @@
  * Alias for j-shift().
  */
 @mixin shift($args...) {
-  @include j-shit($args...);
+  @include j-shift($args...);
 }
 
 /**
@@ -214,7 +214,7 @@
  * Alias for j-unshift().
  */
 @mixin unshift() {
-  @include j-unshit();
+  @include j-unshift();
 }
 
 /**

--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -50,7 +50,7 @@ j-column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
  * Aliases for column.
  */
 column = j-column
-col = column
+col = j-column
 
 /**
  * Get the width of a column and nothing else.
@@ -78,7 +78,7 @@ j-column-gutter(ratios = 1, gutter = jeet.gutter)
  * Aliases for j-column-gutter.
  */
 column-gutter = j-column-gutter
-cg = column-gutter
+cg = j-column-gutter
 
 /**
  * Style an element as a column without any gutters for a seamless row.

--- a/stylus/jeet/_grid.styl
+++ b/stylus/jeet/_grid.styl
@@ -6,7 +6,7 @@
  * @param {number} [uncycle=0] - Undo a previous cycle value to allow for a new one.
  * @param {number} [gutter=jeet.gutter] - Specify the gutter width as a percentage of the containers width.
  */
-column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
+j-column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
   side = jeet-get-layout-direction()
   opposite-side = opposite-position(side)
   column-widths = jeet-get-column(ratios, gutter)
@@ -47,8 +47,9 @@ column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
       margin-{opposite-side}: jeet-get-percentage(margin-last)
 
 /**
- * An alias for the column mixin.
+ * Aliases for column.
  */
+column = j-column
 col = column
 
 /**
@@ -56,25 +57,27 @@ col = column
  * @param {number} [ratios=1] - A width relative to its container as a fraction.
  * @param {number} [gutter=jeet.gutter] - Specify the gutter width as a percentage of the containers width.
  */
-column-width(ratios = 1, gutter = jeet.gutter)
+j-column-width(ratios = 1, gutter = jeet.gutter)
   return jeet-get-percentage(jeet-get-column(ratios, gutter)[0])
 
 /**
- * An alias for the column-width function.
+ * Aliases for j-column-width.
  */
-cw = column-width
+column-width = j-column-width
+cw = j-column-width
 
 /**
  * Get the gutter size of a column and nothing else.
  * @param {number} [ratios=1] - A width relative to its container as a fraction.
  * @param {number} [gutter=jeet.gutter] - Specify the gutter width as a percentage of the containers width.
  */
-column-gutter(ratios = 1, gutter = jeet.gutter)
+j-column-gutter(ratios = 1, gutter = jeet.gutter)
   return jeet-get-percentage(jeet-get-column(ratios, gutter)[1])
 
 /**
- * An alias for the column-gutter function.
+ * Aliases for j-column-gutter.
  */
+column-gutter = j-column-gutter
 cg = column-gutter
 
 /**
@@ -84,7 +87,7 @@ cg = column-gutter
  * @param {number} [cycle=0] - Easily create an nth column grid where cycle equals the number of columns.
  * @param {number} [uncycle=0] - Undo a previous cycle value to allow for a new one.
  */
-span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
+j-span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
   side = jeet-get-layout-direction()
   opposite-side = opposite-position(side)
   span-width = jeet-get-span(ratio)
@@ -117,12 +120,18 @@ span(ratio = 1, offset = 0, cycle = 0, uncycle = 0)
       clear: none
 
 /**
+ * Alias for span.
+ */
+span = j-span
+
+
+/**
  * Reorder columns without altering the HTML.
  * @param {number} [ratios=0] - Specify how far along you want the element to move.
  * @param {string} [col-or-span=column] - Specify whether the element has a gutter or not.
  * @param {number} [gutter=jeet.gutter] - Specify the gutter width as a percentage of the containers width.
  */
-shift(ratios = 0, col-or-span = column, gutter = jeet.gutter)
+j-shift(ratios = 0, col-or-span = column, gutter = jeet.gutter)
   translate = ''
   side = jeet-get-layout-direction()
 
@@ -141,7 +150,7 @@ shift(ratios = 0, col-or-span = column, gutter = jeet.gutter)
 /**
  * Reset an element that has had shift() applied to it.
  */
-unshift()
+j-unshift()
   position: static
   left: 0
 
@@ -150,7 +159,7 @@ unshift()
  * @param {string} [color=black] - The background tint applied.
  * @param {boolean} [important=false] - Whether to apply the style as !important.
  */
-edit(color = black, important = false)
+j-edit(color = black, important = false)
   if important
     *
       background: rgba(color, 5%) !important
@@ -159,16 +168,17 @@ edit(color = black, important = false)
       background: rgba(color, 5%)
 
 /**
- *  Alias for edit().
+ * Aliases for j-edit.
  */
-debug = edit
+edit = j-edit
+debug = j-edit
 
 /**
  * Horizontally center an element.
  * @param {number} [max-width=jeet.max-width] - The max width the element can be.
  * @param {number} [pad=0] - Specify the element's left and right padding.
  */
-center(max-width = jeet.max-width, pad = 0)
+j-center(max-width = jeet.max-width, pad = 0)
   width: auto
   max-width: max-width
   float: none
@@ -179,9 +189,14 @@ center(max-width = jeet.max-width, pad = 0)
   padding-right: pad
 
 /**
+ * Alias for j-center.
+ */
+center = j-center
+
+/**
  * Uncenter an element.
  */
-uncenter()
+j-uncenter()
   max-width: none
   margin-right: 0
   margin-left: 0
@@ -189,11 +204,16 @@ uncenter()
   padding-right: 0
 
 /**
+ * Alias for j-uncenter.
+ */
+uncenter = j-uncenter
+
+/**
  * Stack an element so that nothing is either side of it.
  * @param {number} [pad=0] - Specify the element's left and right padding.
  * @param {bollean/string} [align=false] - Specify the text align for the element.
  */
-stack(pad = 0, align = false)
+j-stack(pad = 0, align = false)
   side = jeet-get-layout-direction()
   opposite-side = opposite-position(side)
 
@@ -223,9 +243,14 @@ stack(pad = 0, align = false)
       text-align: right
 
 /**
+ * Alias for j-stack.
+ */
+stack = j-stack
+
+/**
  * Unstack an element.
  */
-unstack()
+j-unstack()
   side = jeet-get-layout-direction()
   opposite-side = opposite-position(side)
 
@@ -243,11 +268,16 @@ unstack()
     margin-{opposite-side}: 0
 
 /**
+ * Alias for unstack.
+ */
+unstack = j-unstack
+
+/**
  * Center an element on either or both axes.
  * @requires A parent container with relative positioning.
  * @param {string} [direction=both] - Specify which axes to center the element on.
  */
-align(direction = both)
+j-align(direction = both)
   position: absolute
   transform-style: preserve-3d
 
@@ -267,9 +297,14 @@ align(direction = both)
     transform: translate(-50%, -50%)
 
 /**
+ * Alias for j-align.
+ */
+align = j-align
+
+/**
  * Apply a clearfix to an element.
  */
-cf()
+j-cf()
   *zoom: 1
 
   &:before, &:after
@@ -278,3 +313,8 @@ cf()
 
   &:after
     clear: both
+
+/**
+ * Alias for j-cf.
+ */
+cf = j-cf


### PR DESCRIPTION
All methods have aliases so the old API will work, except `shift`/`unshift` in stylus to avoid conflict with core functions.

**Fixes #381**