### PR TITLE
fixed bower.json and prepared for new tag

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "jeet",
-  "version": "6.1.2",
   "homepage": "http://jeet.gs",
   "authors": [
     "Cory Simmons <csimmonswork@gmail.com>",
@@ -9,8 +8,17 @@
   ],
   "description": "A grid system for humans.",
   "main": [
-    "stylus/jeet/index.styl",
-    "scss/jeet/index.scss"
+	  "stylus/jeet/_grid.styl",
+	  "stylus/jeet/index.styl",
+	  "stylus/jeet/_functions.styl",
+	  "stylus/jeet/_settings.styl",
+	  "scss/jeet/_settings.scss",
+	  "scss/jeet/_functions.scss",
+	  "scss/jeet/_grid.scss",
+	  "scss/jeet/index.scss"
+  ],
+  "moduleType": [
+    "node"
   ],
   "keywords": [
     "grid",


### PR DESCRIPTION
Hi there, can you, please, create new tag (6.1.13)?
It is required for bower users, so they can get actual version.(other way they get older 6.1.2 release(dated  Sep 19, 2014))
I've also made a package at bower repos, so you can check differences from yours
```bower install jeet.gs```
and updated version
```bower install jeet.gs_bower```
after your update I'll remove mine package

ps it is also reference at this issue:
https://github.com/mojotech/jeet/issues/433