### PR TITLE
Make aliases into mixins, instead of variables.

### DIFF
--- a/stylus/jeet/_aliases.styl
+++ b/stylus/jeet/_aliases.styl
@@ -1,24 +1,74 @@
 /**
   Aliases
 */
-column = j-column
-column-width = j-column-width
-column-gutter = j-column-gutter
-edit = j-edit
-span = j-span
-shift = j-shift
-unshift = j-shift
-center = j-center
-uncenter = j-uncenter
-stack = j-stack
-unstack = j-unstack
-align = j-align
-cf = j-cf
+column() {
+  j-column()
+}
+
+column-width() {
+  j-column-width()
+}
+
+column-gutter() {
+  j-column-gutter()
+}
+
+edit() {
+  j-edit()
+}
+
+span() {
+  j-span()
+}
+
+shift() {
+  j-shift()
+}
+
+unshift() {
+  j-shift()
+}
+
+center() {
+  j-center()
+}
+
+uncenter() {
+  j-uncenter()
+}
+
+stack() {
+  j-stack()
+}
+
+unstack() {
+  j-unstack()
+}
+
+align() {
+  j-align()
+}
+
+cf() {
+  j-cf()
+}
 
 /**
   Alias shortcuts
 */
-col = column
-cw = column-width
-cg = column-gutter
-debug = edit
+col() {
+  column()
+}
+
+cw() {
+  column-width()
+}
+
+cg() {
+  column-gutter()
+}
+
+debug() {
+  edit()
+}
+


### PR DESCRIPTION
This fixes issues where an alias has the same name as a CSS property or tag name ("center", "span")