### PR TITLE
Implemented Media mixins

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -63,3 +63,15 @@ Aligning blocks relative to their container (so their parent container needs `po
 ### clearfix()
 
 A simple/kinda-modern clearfix. Use this to wrap any set of `column()`s or `span()`s. If you need super-old browser support, you can create your own clearfix mixin (use the `clearfix` namespace) with stuff like `:before` and `*zoom: 1` (look up an old clearfix).
+
+### media-row()
+
+A row for a simple media object. This is needed when a media object is going to be used and wraps all media elements together.
+
+### media($fill: false, $spacing-left: false, $spacing-right: false)
+
+Defines a media object column. `$fill` says that the media element should always take the whole, available space. `$spacing-left` or `$spacing-right` can be used to add inner paddings and add spacings to other media object columns.
+
+### unmedia($reset-fill: false)
+
+Resets a media object column and works similar to `stack()`.

--- a/scss/_media.scss
+++ b/scss/_media.scss
@@ -1,0 +1,31 @@
+@mixin media-row() {
+  overflow: hidden;
+  zoom: 1;
+
+  &:first-child {
+    margin-top: 0;
+  }
+}
+
+@mixin media($fill: false, $spacing-left: false, $spacing-right: false) {
+  display: table-cell;
+
+  @if $fill {
+    width: 1000000px;
+  }
+
+  @if $spacing-left {
+    padding-left: $spacing-left;
+  }
+
+  @if $spacing-right {
+    padding-right: $spacing-right;
+  }
+}
+
+@mixin unmedia() {
+  display: block;
+  padding-left: 0;
+  padding-right: 0;
+  width: auto;
+}

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -13,7 +13,11 @@
 // unstack()
 // align($direction: both)
 // clearfix()
+// media-row()
+// media($fill: false, $spacing-left: false, $spacing-right: false)
+// unmedia()
 
 @import '_settings';
 @import '_functions';
 @import '_grid';
+@import '_media';

--- a/styl/_media.styl
+++ b/styl/_media.styl
@@ -1,0 +1,26 @@
+media-row()
+  overflow: hidden
+  zoom: 1
+
+  &:first-child
+    margin-top: 0
+
+media($fill = false, $spacing-left = false, $spacing-right = false)
+  display: table-cell
+
+  if $fill
+    width: 1000000px
+
+  if $spacing-left
+    padding-left: $spacing-left
+
+  if $spacing-right
+    padding-right: $spacing-right
+
+unmedia($reset-spacing = flase)
+  display: block
+  padding-left: 0
+  padding-right: 0
+
+  if $reset-spacing
+    width: auto

--- a/styl/_media.styl
+++ b/styl/_media.styl
@@ -17,10 +17,8 @@ media($fill = false, $spacing-left = false, $spacing-right = false)
   if $spacing-right
     padding-right: $spacing-right
 
-unmedia($reset-spacing = flase)
+unmedia()
   display: block
   padding-left: 0
   padding-right: 0
-
-  if $reset-spacing
-    width: auto
+  width: auto

--- a/styl/index.styl
+++ b/styl/index.styl
@@ -13,7 +13,11 @@
 // unstack()
 // align($direction = both)
 // clearfix()
+// media-row()
+// media($fill = 1, $spacing-left = false, $spacing-right = false)
+// media($reset-spacing = false)
 
 @import '_settings'
 @import '_functions'
 @import '_grid'
+@import '_media'

--- a/styl/index.styl
+++ b/styl/index.styl
@@ -15,7 +15,7 @@
 // clearfix()
 // media-row()
 // media($fill = 1, $spacing-left = false, $spacing-right = false)
-// media($reset-spacing = false)
+// media()
 
 @import '_settings'
 @import '_functions'


### PR DESCRIPTION
This pull requests adds mixins for [media objects](http://getbootstrap.com/components/#media). Since media objects are also used to define layouts I think it makes sense to also add them to jeet.

I'm a daily jeet user and I write all my media objects by hand and I'm really missing that feature from jeet.

What do you think? Does it fit into the project?